### PR TITLE
Double use offset variable

### DIFF
--- a/src/Access.php
+++ b/src/Access.php
@@ -27,7 +27,7 @@ final class Access implements \ArrayAccess {
   }
 
   function offsetGet($offset) {
-    return new Access(function ($x) use ($offset, $offset) {
+    return new Access(function ($x) use ($offset) {
       return $this($x)[$offset];
     });
   }


### PR DESCRIPTION
PHP 7.1 does not allow double use of `$offset` in `use ()`